### PR TITLE
[bug] Salvar formulário de profissional não aparece um loading #26

### DIFF
--- a/src/app/professional/professional-edit/professional-edit.component.ts
+++ b/src/app/professional/professional-edit/professional-edit.component.ts
@@ -131,7 +131,9 @@ export class ProfessionalEditComponent implements OnInit {
       }
     });
     if (this.dataToForm.id) {
+      this.loading = true;
       this.professionalService.update(this.dataToForm).then(resp => {
+        this.loading = false;
         this.dataToForm = resp;
         if (!resp.address) {
           this.dataToForm.address = new Address();
@@ -142,7 +144,9 @@ export class ProfessionalEditComponent implements OnInit {
         this.errorHandler.handle(error, this.dialogRef);
       });
     } else {
+      this.loading = true;
       this.professionalService.create(this.dataToForm).then(resp => {
+        this.loading = false;
         this.dataToForm = resp;
         if (!resp.address) {
           this.dataToForm.address = new Address();


### PR DESCRIPTION

Closes #10
--
# Descrição

Um loading de feedback foi adicionado à tela para que o usuário não clique mais de uma vez no botão salvar.

## Tipo de alteração

Não marque as opções que não são relevantes.

- [x] Correção de bug (alteração ininterrupta que corrige um problema)
- [ ] Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [ ] Quebra de alteração (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [ ] Esta alteração requer uma atualização da documentação

# Como isso foi testado?

Foi realizado uma atualização cadastro dos dados do profissional e em seguida apertei para salvar, um loading apareceu no meio da tela e bloqueou os controles enquanto o processo era realizado, como mostra a imagem abaixo:
![image](https://user-images.githubusercontent.com/7918549/87884218-4b852e80-c9e3-11ea-9f3f-60168be36410.png)


# Lista de controle:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Eu realizei uma auto-revisão do meu próprio código
- [x] Comentei meu código, principalmente em áreas difíceis de entender
- [x] Fiz as alterações correspondentes na documentação
- [ ] Minhas alterações não geram novos avisos
- [x] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [ ] Os testes de unidade novos e existentes passam localmente com minhas alterações
